### PR TITLE
template: put space to separate time in log

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -24,7 +24,7 @@ http {
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"'
+                      '"$http_user_agent" "$http_x_forwarded_for" '
                       '$request_time $upstream_response_time $pipe';
 
     access_log  {{ nginx_access_log }};


### PR DESCRIPTION
Just a improvement. Put a space after to separate time log.