### PR TITLE
feat/nginx: add send_timeout config to override default timeout

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,7 @@ nginx_tcp_nodelay: "on"
 
 nginx_keepalive_timeout: "65"
 nginx_keepalive_requests: "100"
+nginx_send_timeout: "60s"
 
 nginx_client_max_body_size: "64m"
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -41,6 +41,7 @@ http {
 
     keepalive_timeout  {{ nginx_keepalive_timeout }};
     keepalive_requests {{ nginx_keepalive_requests }};
+    send_timeout {{ nginx_send_timeout }};
 
     #gzip  on;
 


### PR DESCRIPTION
feat/nginx: add send_timeout config to override default timeout