### PR TITLE
bug/apt-module:

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,5 +6,5 @@
 - name: Ensure nginx is installed.
   apt:
     name: "{{ nginx_package_name }}"
-    state: installed
+    state: present
     default_release: "{{ nginx_default_release }}"


### PR DESCRIPTION
Ansible apt module supports only: absent, build-dep, latest, present and fixed

https://docs.ansible.com/ansible/latest/modules/apt_module.html